### PR TITLE
Adding detection of JSON.Net version for line info handling

### DIFF
--- a/src/Microsoft.VisualStudio.Jdt.Tests/Microsoft.VisualStudio.Jdt.Tests.csproj
+++ b/src/Microsoft.VisualStudio.Jdt.Tests/Microsoft.VisualStudio.Jdt.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MicroBuild.NonShipping" Version="2.0.40" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170425-07" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Jdt/JdtExtensions.cs
+++ b/src/Microsoft.VisualStudio.Jdt/JdtExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.Jdt
         {
             var loadSettings = new JsonLoadSettings()
             {
-                LineInfoHandling = LineInfoHandling.Load
+                LineInfoHandling = JdtUtilities.GetLineInfoHandling()
             };
 
             using (var objectReader = objectToClone.CreateReader())

--- a/src/Microsoft.VisualStudio.Jdt/JdtUtilities.cs
+++ b/src/Microsoft.VisualStudio.Jdt/JdtUtilities.cs
@@ -57,17 +57,15 @@ namespace Microsoft.VisualStudio.Jdt
 
                 if (newtonsoftVersion >= new Version("10.0.2"))
                 {
-                    return LineInfoHandling.Load;
+                    lineInfoHandling = LineInfoHandling.Load;
                 }
                 else
                 {
-                    return LineInfoHandling.Ignore;
+                    lineInfoHandling = LineInfoHandling.Ignore;
                 }
             }
-            else
-            {
-                return lineInfoHandling.Value;
-            }
+
+            return lineInfoHandling.Value;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Jdt/JsonTransformation.cs
+++ b/src/Microsoft.VisualStudio.Jdt/JsonTransformation.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.Jdt
             this.loadSettings = new JsonLoadSettings()
             {
                 CommentHandling = CommentHandling.Ignore,
-                LineInfoHandling = LineInfoHandling.Load
+                LineInfoHandling = JdtUtilities.GetLineInfoHandling()
             };
 
             using (StreamReader transformStreamReader = new StreamReader(transformStream))

--- a/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
+++ b/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
+++ b/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
@@ -21,11 +21,12 @@
 
   <ItemGroup>
     <PackageReference Include="MicroBuild.VisualStudio" Version="2.0.40" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Jdt/Processors/Attributes/JdtAttributeExtensions.cs
+++ b/src/Microsoft.VisualStudio.Jdt/Processors/Attributes/JdtAttributeExtensions.cs
@@ -5,9 +5,7 @@ namespace Microsoft.VisualStudio.Jdt
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Linq;
-    using System.Reflection;
 
     /// <summary>
     /// Implements extensions for <see cref="JdtAttributes"/>
@@ -15,36 +13,18 @@ namespace Microsoft.VisualStudio.Jdt
     internal static class JdtAttributeExtensions
     {
         /// <summary>
-        /// Gets the description (name) of the attribute
-        /// </summary>
-        /// <param name="attribute">The attribute</param>
-        /// <returns>The name of the attribute</returns>
-        internal static string GetDescription(this JdtAttributes attribute)
-        {
-            var type = attribute.GetType();
-            var typeInfo = type.GetTypeInfo();
-            var name = Enum.GetName(type, attribute);
-            var description = typeInfo.GetField(name)
-                .GetCustomAttributes(false)
-                .OfType<DescriptionAttribute>()
-                .SingleOrDefault();
-
-            if (description == null)
-            {
-                throw new NotImplementedException(attribute.ToString() + " does not have a corresponding name");
-            }
-
-            return description.Description;
-        }
-
-        /// <summary>
         /// Get the full name of an attribute, with the JDT prefix
         /// </summary>
         /// <param name="attribute">The attribute</param>
         /// <returns>A string with the full name of the requested attribute</returns>
         internal static string FullName(this JdtAttributes attribute)
         {
-            return JdtUtilities.JdtSyntaxPrefix + attribute.GetDescription();
+            if (attribute == JdtAttributes.None)
+            {
+                return JdtUtilities.JdtSyntaxPrefix;
+            }
+
+            return JdtUtilities.JdtSyntaxPrefix + Enum.GetName(typeof(JdtAttributes), attribute).ToLower();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.Jdt/Processors/Attributes/JdtAttributeValidator.cs
+++ b/src/Microsoft.VisualStudio.Jdt/Processors/Attributes/JdtAttributeValidator.cs
@@ -5,7 +5,6 @@ namespace Microsoft.VisualStudio.Jdt
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Linq;
     using Newtonsoft.Json.Linq;
 
@@ -17,19 +16,16 @@ namespace Microsoft.VisualStudio.Jdt
         /// <summary>
         /// Represents an non existant attribute
         /// </summary>
-        [Description(null)]
         None = 0,
 
         /// <summary>
         /// The JDT path attribute
         /// </summary>
-        [Description("path")]
         Path,
 
         /// <summary>
         /// The JDT path attribute
         /// </summary>
-        [Description("value")]
         Value,
     }
 


### PR DESCRIPTION
A bug in previous versions of JSON.Net loaded line info on ignore and vice versa.

This detects the verion of JSON.Net and acts accordingly