### PR TITLE
updating copyright version

### DIFF
--- a/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
+++ b/src/Microsoft.VisualStudio.Jdt/Microsoft.VisualStudio.Jdt.csproj
@@ -9,7 +9,7 @@
      <Authors>Microsoft</Authors>
      <Owners>Microsoft, VisualStudioExtensibility</Owners>
      <Description>Transform json files using a json transformation schema</Description>
-     <Copyright>Copyright © Microsoft Corporation. All rights reserved.</Copyright>
+     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
      <PackageTags>json transformation transforms file-transform jdt</PackageTags>
      <PackageIconUrl>https://aka.ms/VsExtensibilityIcon</PackageIconUrl>
      <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Release pipeline for JDT needs the copyright message to be different in order to publish a new version. So doing that udpate