### PR TITLE
Update JDT to use new microbuild task.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,21 +232,14 @@ extends:
               !**/*Test*
             TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-        - task: PublishSymbols@2
-          inputs:
-            SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-            SearchPattern: '**\*.pdb'
-            SymbolServerType: TeamServices
-            PublishSymbols: false
-          displayName: Archive symbols to VSTS
-          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
-          
+
         - task: MicroBuildArchiveSymbols@5
           displayName: 🔣 Archive symbols to Symweb
           inputs:
             SymbolsFeatureName: $(SymbolsFeatureName)
             SymbolsProject: VS
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
+
 
         - task: CopyFiles@1
           displayName: Collecting packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,11 +237,15 @@ extends:
             SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
             SearchPattern: '**\*.pdb'
             SymbolServerType: TeamServices
-            ArtifactServices.Symbol.AccountName: microsoft
-            ArtifactServices.Symbol.PAT: $(System.AccessToken)
-            ArtifactServices.Symbol.UseAAD: false
           displayName: Archive symbols to VSTS
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
+          
+        - task: MicroBuildArchiveSymbols@5
+          displayName: 🔣 Archive symbols to Symweb
+          inputs:
+            SymbolsFeatureName: $(SymbolsFeatureName)
+            SymbolsProject: VS
+
         - task: CopyFiles@1
           displayName: Collecting packages
           inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,6 +237,8 @@ extends:
             SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
             SearchPattern: '**\*.pdb'
             SymbolServerType: TeamServices
+            IndexSources: false
+            PublishSymbols: false
           displayName: Archive symbols to VSTS
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
           

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,7 +237,6 @@ extends:
             SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
             SearchPattern: '**\*.pdb'
             SymbolServerType: TeamServices
-            IndexSources: false
             PublishSymbols: false
           displayName: Archive symbols to VSTS
           condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,6 +245,7 @@ extends:
           inputs:
             SymbolsFeatureName: $(SymbolsFeatureName)
             SymbolsProject: VS
+          condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SignType'], 'real'))
 
         - task: CopyFiles@1
           displayName: Collecting packages


### PR DESCRIPTION
Changed how we archive symbols to match that of the new guidelines.
Also removed publishing since it only would be used for indexing and there is an issue there.
https://github.com/microsoft/azure-pipelines-tasks/issues/15605